### PR TITLE
Add TLS client and use Glide for dependency management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 riemann.log
 riemann-*
+vendor

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Go client library for [Riemann](https://github.com/riemann/riemann).
 Features:
 * Idiomatic concurrency
 * Sending events, queries.
-* Support tcp and udp client.
+* Support TCP, UDP, TLS clients.
 
 This client is a fork of Goryman, a Riemann go client written by Christopher Gilbert. Thanks and full credit to him!
 
@@ -60,6 +60,18 @@ if err != nil {
 }
 ```
 
+You can also create a TLS client.
+The second parameter is the path to your client certificate, the third parameter the path to your client key. The last parameter allows you to create an insecure connection (insecure certificate check).
+You can find more informations about how to configure TLS in Riemann [here](http://riemann.io/howto.html#securing-traffic-using-tls).
+
+```go
+c := riemanngo.NewTlsClient("127.0.0.1:5554", "/path/to/cert.pem", "/path/to/key.key", true)
+err := c.Connect(5)
+if err != nil {
+    panic(err)
+}
+```
+
 Don't forget to close the client connection when you're done:
 
 ```go
@@ -95,10 +107,10 @@ riemanngo.Event{
 }
 ```
 
-You can also query the Riemann index (using the TCP client):
+You can also query the Riemann index (using the TCP or TLS client):
 
 ```go
-events, err := c.QueryEvents("service = \"hello\"")
+events, err := c.QueryIndex("service = \"hello\"")
 if err != nil {
     panic(err)
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,8 @@
+hash: f2bb382e726e61467c3869e256146dd06cfbdc6927cf47886284579407c70d99
+updated: 2017-03-08T22:33:40.643398374+01:00
+imports:
+- name: github.com/golang/protobuf
+  version: c9c7427a2a70d2eb3bafa0ab2dc163e45f143317
+  subpackages:
+  - proto
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,5 @@
+package: github.com/riemann/riemann-go-client
+import:
+- package: github.com/golang/protobuf
+  subpackages:
+  - proto

--- a/tls.go
+++ b/tls.go
@@ -1,0 +1,147 @@
+package riemanngo
+
+import (
+	"bytes"
+	"encoding/binary"
+	"crypto/tls"
+	"io/ioutil"
+	"crypto/x509"
+	"net"
+	"time"
+	"strings"
+
+	pb "github.com/golang/protobuf/proto"
+	"github.com/riemann/riemann-go-client/proto"
+)
+
+// TlsClient is a type that implements the Client interface
+type TlsClient struct {
+	addr          string
+	tlsConfig     tls.Config
+	conn          net.Conn
+	requestQueue chan request
+}
+
+// NewTlsClient - Factory
+func NewTlsClient(addr string, certPath string, keyPath string, insecure bool) (*TlsClient, error) {
+	certFile, err := ioutil.ReadFile(certPath)
+	if err != nil {
+		return nil, err
+	}
+
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, err
+	}
+	clientCertPool := x509.NewCertPool()
+	clientCertPool.AppendCertsFromPEM(certFile)
+
+	config := tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      clientCertPool,
+		InsecureSkipVerify: insecure}
+
+	if !insecure {
+		serverName := strings.Split(addr, ":")[0]
+		config.ServerName = serverName
+	}
+
+	t := &TlsClient{
+		addr:         addr,
+		tlsConfig:    config,
+		requestQueue: make(chan request),
+	}
+	go t.runRequestQueue()
+	return t, nil
+}
+
+// connect the TlsClient
+func (c *TlsClient) Connect(timeout int32) error {
+	tcp, err := net.DialTimeout("tcp", c.addr, time.Second*time.Duration(timeout))
+	if err != nil {
+		return err
+	}
+	tlsConn := tls.Client(tcp, &c.tlsConfig)
+	c.conn = tlsConn
+	return nil
+}
+
+
+// TlsClient implementation of Send, queues a request to send a message to the server
+func (t *TlsClient) Send(message *proto.Msg) (*proto.Msg, error) {
+	response_ch := make(chan response)
+	t.requestQueue <- request{message, response_ch}
+	r := <-response_ch
+	return r.message, r.err
+}
+
+// Close will close the TlsClient
+func (t *TlsClient) Close() error {
+	close(t.requestQueue)
+	err := t.conn.Close()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// runRequestQueue services the TlsClient request queue
+func (t *TlsClient) runRequestQueue() {
+	for req := range t.requestQueue {
+		message := req.message
+		response_ch := req.response_ch
+
+		msg, err := t.execRequest(message)
+
+		response_ch <- response{msg, err}
+	}
+}
+
+// execRequest will send a TCP message (using tls) to Riemann
+func (t *TlsClient) execRequest(message *proto.Msg) (*proto.Msg, error) {
+	msg := &proto.Msg{}
+	data, err := pb.Marshal(message)
+	if err != nil {
+		return msg, err
+	}
+	b := new(bytes.Buffer)
+	if err = binary.Write(b, binary.BigEndian, uint32(len(data))); err != nil {
+		return msg, err
+	}
+	// send the msg length
+	if _, err = t.conn.Write(b.Bytes()); err != nil {
+		return msg, err
+	}
+	// send the msg
+	if _, err = t.conn.Write(data); err != nil {
+		return msg, err
+	}
+	var header uint32
+	if err = binary.Read(t.conn, binary.BigEndian, &header); err != nil {
+		return msg, err
+	}
+	response := make([]byte, header)
+	if err = readMessages(t.conn, response); err != nil {
+		return msg, err
+	}
+	if err = pb.Unmarshal(response, msg); err != nil {
+		return msg, err
+	}
+	return msg, nil
+}
+
+// Query the server for events using the client
+func (c *TlsClient) QueryIndex(q string) ([]Event, error) {
+	query := &proto.Query{}
+	query.String_ = pb.String(q)
+
+	message := &proto.Msg{}
+	message.Query = query
+
+	response, err := c.Send(message)
+	if err != nil {
+		return nil, err
+	}
+
+	return ProtocolBuffersToEvents(response.GetEvents()), nil
+}


### PR DESCRIPTION
This PR adds the tls client.
We are also using Glide (http://glide.sh/) to manage dependencies and
to allow reproducible builds.

Fix #4 