### PR TITLE
Test if the Metric field is nil when converting to protobuf

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -54,16 +54,18 @@ func EventToProtocolBuffer(event *Event) (*proto.Event, error) {
 		e.Ttl = pb.Float32(event.Ttl)
 	}
 
-	switch reflect.TypeOf(event.Metric).Kind() {
-	case reflect.Int, reflect.Int32, reflect.Int64:
-		e.MetricSint64 = pb.Int64((reflect.ValueOf(event.Metric).Int()))
-	case reflect.Float32:
-		e.MetricD = pb.Float64((reflect.ValueOf(event.Metric).Float()))
-	case reflect.Float64:
-		e.MetricD = pb.Float64((reflect.ValueOf(event.Metric).Float()))
-	default:
-		return nil, fmt.Errorf("Metric of invalid type (type %v)",
-			reflect.TypeOf(event.Metric).Kind())
+	if event.Metric != nil {
+		switch reflect.TypeOf(event.Metric).Kind() {
+		case reflect.Int, reflect.Int32, reflect.Int64:
+			e.MetricSint64 = pb.Int64((reflect.ValueOf(event.Metric).Int()))
+		case reflect.Float32:
+			e.MetricD = pb.Float64((reflect.ValueOf(event.Metric).Float()))
+		case reflect.Float64:
+			e.MetricD = pb.Float64((reflect.ValueOf(event.Metric).Float()))
+		default:
+			return nil, fmt.Errorf("Metric of invalid type (type %v)",
+				reflect.TypeOf(event.Metric).Kind())
+		}
 	}
 	return &e, nil
 }

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -233,6 +233,26 @@ func TestEventToProtocolBuffer(t *testing.T) {
 	if !pb.Equal(protoRes, &protoTest) {
 		t.Error("Error during event to protobuf conversion")
 	}
+
+	// Event without metrics
+	event = Event{
+		Host:    "baz",
+		Service: "foobar",
+		Time:    time.Unix(100, 123456789),
+	}
+	protoRes, error = EventToProtocolBuffer(&event)
+	if error != nil {
+		t.Error("Error during EventToProtocolBuffer")
+	}
+	protoTest = proto.Event{
+		Host:       pb.String("baz"),
+		Service:    pb.String("foobar"),
+		Time:       pb.Int64(100),
+		TimeMicros: pb.Int64(100123456),
+	}
+	if !pb.Equal(protoRes, &protoTest) {
+		t.Error("Error during event to protobuf conversion")
+	}
 }
 
 func compareEvents(e1 *Event, e2 *Event, t *testing.T) {


### PR DESCRIPTION
If an event was sent without the Metric field set, a segfault occured:

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x98 pc=0x57aedb]
```

This PR fix the issue by checking if the Metric field is nil or not.