### PR TITLE
Add support for uint types in Metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ if err != nil {
 }
 ```
 
+### Uint metric type
+
+The event `Metric` value can have `uint` (or `uint32`, `uint64`) as type. In this case, this value will be converted to `int64`, which can cause issues.
+
 ## Tests
 
 You can lauch tests using

--- a/marshal.go
+++ b/marshal.go
@@ -57,11 +57,13 @@ func EventToProtocolBuffer(event *Event) (*proto.Event, error) {
 	if event.Metric != nil {
 		switch reflect.TypeOf(event.Metric).Kind() {
 		case reflect.Int, reflect.Int32, reflect.Int64:
-			e.MetricSint64 = pb.Int64((reflect.ValueOf(event.Metric).Int()))
+			e.MetricSint64 = pb.Int64(reflect.ValueOf(event.Metric).Int())
 		case reflect.Float32:
-			e.MetricD = pb.Float64((reflect.ValueOf(event.Metric).Float()))
+			e.MetricD = pb.Float64(reflect.ValueOf(event.Metric).Float())
 		case reflect.Float64:
-			e.MetricD = pb.Float64((reflect.ValueOf(event.Metric).Float()))
+			e.MetricD = pb.Float64(reflect.ValueOf(event.Metric).Float())
+		case reflect.Uint, reflect.Uint32, reflect.Uint64:
+			e.MetricSint64 = pb.Int64(int64(reflect.ValueOf(event.Metric).Uint()))
 		default:
 			return nil, fmt.Errorf("Metric of invalid type (type %v)",
 				reflect.TypeOf(event.Metric).Kind())

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -253,6 +253,52 @@ func TestEventToProtocolBuffer(t *testing.T) {
 	if !pb.Equal(protoRes, &protoTest) {
 		t.Error("Error during event to protobuf conversion")
 	}
+
+	// Event with uint type
+	var muint uint64 = 5
+	event = Event{
+		Host:    "baz",
+		Metric:  muint,
+		Service: "foobar",
+		Time:    time.Unix(100, 123456789),
+	}
+	protoRes, error = EventToProtocolBuffer(&event)
+	if error != nil {
+		t.Error("Error during EventToProtocolBuffer")
+	}
+	protoTest = proto.Event{
+		Host:         pb.String("baz"),
+		Service:      pb.String("foobar"),
+		Time:         pb.Int64(100),
+		TimeMicros:   pb.Int64(100123456),
+		MetricSint64: pb.Int64(5),
+	}
+	if !pb.Equal(protoRes, &protoTest) {
+		t.Error("Error during event to protobuf conversion")
+	}
+
+	// Event with uint type, overflow
+	muint = 18446744073709551615
+	event = Event{
+		Host:    "baz",
+		Metric:  muint,
+		Service: "foobar",
+		Time:    time.Unix(100, 123456789),
+	}
+	protoRes, error = EventToProtocolBuffer(&event)
+	if error != nil {
+		t.Error("Error during EventToProtocolBuffer")
+	}
+	protoTest = proto.Event{
+		Host:         pb.String("baz"),
+		Service:      pb.String("foobar"),
+		Time:         pb.Int64(100),
+		TimeMicros:   pb.Int64(100123456),
+		MetricSint64: pb.Int64(-1),
+	}
+	if !pb.Equal(protoRes, &protoTest) {
+		t.Error("Error during event to protobuf conversion")
+	}
 }
 
 func compareEvents(e1 *Event, e2 *Event, t *testing.T) {


### PR DESCRIPTION
It's now possible to use uint, uint32 or uint64 for the Metric value.
I added a warning in the README, because the conversion uint => int64 can cause issues (for example 0xFFFFFFFFFFFFFFFF => -1). 