### PR TITLE
Add timeout on clients write.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-RIEMANN_VERSION = 0.2.13
+RIEMANN_VERSION = 0.3.0
 
 all:    install
 

--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ import (
 )
 ```
 
-Next, we'll need to establish a new client. The parameter is the connection timeout duration. You can use a TCP client:
+Next, we'll need to establish a new client. The parameters are the Riemann address and the connection timeout duration. You can use a TCP client:
 
 
 ```go
-c := riemanngo.NewTcpClient("127.0.0.1:5555")
-err := c.Connect(5)
+c := riemanngo.NewTcpClient("127.0.0.1:5555", 5*time.Second)
+err := c.Connect()
 if err != nil {
     panic(err)
 }
@@ -58,20 +58,20 @@ if err != nil {
 Or a UDP client:
 
 ```go
-c := riemanngo.NewUdpClient("127.0.0.1:5555")
-err := c.Connect(5)
+c := riemanngo.NewUdpClient("127.0.0.1:5555", 5*time.Second)
+err := c.Connect()
 if err != nil {
     panic(err)
 }
 ```
 
 You can also create a TLS client.
-The second parameter is the path to your client certificate, the third parameter the path to your client key. The last parameter allows you to create an insecure connection (insecure certificate check).
+The second parameter is the path to your client certificate, the third parameter the path to your client key. The next parameter allows you to create an insecure connection (insecure certificate check). The last parameter is the connect and write timeout.
 You can find more informations about how to configure TLS in Riemann [here](http://riemann.io/howto.html#securing-traffic-using-tls).
 
 ```go
-c := riemanngo.NewTlsClient("127.0.0.1:5554", "/path/to/cert.pem", "/path/to/key.key", true)
-err := c.Connect(5)
+c := riemanngo.NewTlsClient("127.0.0.1:5554", "/path/to/cert.pem", "/path/to/key.key", true, 5*time.Second)
+err := c.Connect()
 if err != nil {
     panic(err)
 }

--- a/client.go
+++ b/client.go
@@ -10,7 +10,7 @@ import (
 // Client is an interface to a generic client
 type Client interface {
 	Send(message *proto.Msg) (*proto.Msg, error)
-	Connect(timeout int32) error
+	Connect() error
 	Close() error
 }
 

--- a/tcp_integration_test.go
+++ b/tcp_integration_test.go
@@ -4,11 +4,12 @@ package riemanngo
 
 import (
 	"testing"
+	"time"
 )
 
 func TestSendEventTcp(t *testing.T) {
-	c := NewTcpClient("127.0.0.1:5555")
-	err := c.Connect(5)
+	c := NewTcpClient("127.0.0.1:5555", 5*time.Second)
+	err := c.Connect()
 	defer c.Close()
 	if err != nil {
 		t.Error("Error Tcp client Connect")
@@ -24,8 +25,8 @@ func TestSendEventTcp(t *testing.T) {
 }
 
 func TestSendEventsTcp(t *testing.T) {
-	c := NewTcpClient("127.0.0.1:5555")
-	err := c.Connect(5)
+	c := NewTcpClient("127.0.0.1:5555", 5*time.Second)
+	err := c.Connect()
 	defer c.Close()
 	if err != nil {
 		t.Error("Error Tcp client Connect")
@@ -49,8 +50,8 @@ func TestSendEventsTcp(t *testing.T) {
 }
 
 func TestQueryIndex(t *testing.T) {
-	c := NewTcpClient("127.0.0.1:5555")
-	err := c.Connect(5)
+	c := NewTcpClient("127.0.0.1:5555", 5*time.Second)
+	err := c.Connect()
 	defer c.Close()
 	if err != nil {
 		t.Error("Error Tcp client Connect")
@@ -80,9 +81,9 @@ func TestQueryIndex(t *testing.T) {
 }
 
 func TestTcpConnec(t *testing.T) {
-	c := NewTcpClient("does.not.exists:8888")
+	c := NewTcpClient("does.not.exists:8888", 5*time.Second)
 	// should produce an error
-	err := c.Connect(2)
+	err := c.Connect()
 	if err == nil {
 		t.Error("Error, should fail")
 	}

--- a/tcp_test.go
+++ b/tcp_test.go
@@ -2,10 +2,11 @@ package riemanngo
 
 import (
 	"testing"
+	"time"
 )
 
 func TestNewTcpClient(t *testing.T) {
-	client := NewTcpClient("127.0.0.1:5555")
+	client := NewTcpClient("127.0.0.1:5555", 5*time.Second)
 	if client.addr != "127.0.0.1:5555" {
 		t.Error("Error creating a new tcp client")
 	}

--- a/tls_test.go
+++ b/tls_test.go
@@ -2,10 +2,11 @@ package riemanngo
 
 import (
 	"testing"
+	"time"
 )
 
 func TestNewTlsClientWithInsecure(t *testing.T) {
-	client, err := NewTlsClient("127.0.0.1:5555", "tls/client.crt", "tls/client.key", true)
+	client, err := NewTlsClient("127.0.0.1:5555", "tls/client.crt", "tls/client.key", true, 5*time.Second)
 	if err != nil {
 		t.Error("Error creating a new tls client")
 	}
@@ -15,7 +16,7 @@ func TestNewTlsClientWithInsecure(t *testing.T) {
 }
 
 func TestNewTlsClientWithoutInsecure(t *testing.T) {
-	client, err := NewTlsClient("127.0.0.1:5555", "tls/client.crt", "tls/client.key", false)
+	client, err := NewTlsClient("127.0.0.1:5555", "tls/client.crt", "tls/client.key", false, 5*time.Second)
 	if err != nil {
 		t.Error("Error creating a new tls client")
 	}

--- a/udp_integration_test.go
+++ b/udp_integration_test.go
@@ -4,11 +4,12 @@ package riemanngo
 
 import (
 	"testing"
+	"time"
 )
 
 func TestSendEventUdp(t *testing.T) {
-	c := NewUdpClient("127.0.0.1:5555")
-	err := c.Connect(5)
+	c := NewUdpClient("127.0.0.1:5555", 5*time.Second)
+	err := c.Connect()
 	defer c.Close()
 	if err != nil {
 		t.Error("Error Udp client Connect")
@@ -24,8 +25,8 @@ func TestSendEventUdp(t *testing.T) {
 }
 
 func TestSendEventsUdp(t *testing.T) {
-	c := NewUdpClient("127.0.0.1:5555")
-	err := c.Connect(5)
+	c := NewUdpClient("127.0.0.1:5555", 5*time.Second)
+	err := c.Connect()
 	defer c.Close()
 	if err != nil {
 		t.Error("Error Udp client Connect")
@@ -49,9 +50,9 @@ func TestSendEventsUdp(t *testing.T) {
 }
 
 func TestUdpConnec(t *testing.T) {
-	c := NewUdpClient("does.not.exists:8888")
+	c := NewUdpClient("does.not.exists:8888", 5*time.Second)
 	// should produce an error
-	err := c.Connect(2)
+	err := c.Connect()
 	if err == nil {
 		t.Error("Error, should fail")
 	}

--- a/udp_test.go
+++ b/udp_test.go
@@ -2,10 +2,11 @@ package riemanngo
 
 import (
 	"testing"
+	"time"
 )
 
 func TestNewUdpClient(t *testing.T) {
-	client := NewUdpClient("127.0.0.1:5555")
+	client := NewUdpClient("127.0.0.1:5555", 5*time.Second)
 	if client.addr != "127.0.0.1:5555" {
 		t.Error("Error creating a new tcp client")
 	}


### PR DESCRIPTION
- Modify the Client interface, removing the timeout parameter in
  Connect
- Add a timeout parameter to clients factories
- Set timeout on clients write.

This is a minor beaking change, the "timeout" parameter for Connect() should now be passed to the client factory.