### PR TITLE
Fixed connection initialization with a multiplied timeout

### DIFF
--- a/tcp.go
+++ b/tcp.go
@@ -32,7 +32,7 @@ func NewTcpClient(addr string, timeout time.Duration) *TcpClient {
 
 // connect the TcpClient
 func (c *TcpClient) Connect() error {
-	tcp, err := net.DialTimeout("tcp", c.addr, time.Second*time.Duration(c.timeout))
+	tcp, err := net.DialTimeout("tcp", c.addr, c.timeout)
 	if err != nil {
 		return err
 	}

--- a/udp.go
+++ b/udp.go
@@ -32,7 +32,7 @@ func NewUdpClient(addr string, timeout time.Duration) *UdpClient {
 }
 
 func (c *UdpClient) Connect() error {
-	udp, err := net.DialTimeout("udp", c.addr, time.Second*time.Duration(c.timeout))
+	udp, err := net.DialTimeout("udp", c.addr, c.timeout)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In the riemann-go-client with timeout as type time.Duration (and not int32, as it was some time back),  for net.DialTimeout, the timeout should not be multiplied with time.Second, as it will multiply the given Duration by 1,000,000,000.